### PR TITLE
rep has no nrow argument

### DIFF
--- a/R/corLocal.R
+++ b/R/corLocal.R
@@ -35,7 +35,7 @@ setMethod('corLocal', signature(x='RasterLayer', y='RasterLayer'),
 					}
 				}
 			} else {
-				v <- rep(NA, nrow=ncell(x))
+				v <- rep(NA, ncell(x))
 				for (i in 1:ncell(x)) {
 					z <- stats::na.omit(cbind(vx[i,], vy[i,]))	
 					if (nrow(z) > 2) {


### PR DESCRIPTION
therefore it is ignored, most likely it was an autocomplete typo. This yields an error when NA values exists.
The problem can be replicated like this, using the code from the corLocal example:

set.seed(0)
b <- stack(system.file("external/rlogo.grd", package="raster"))
b[[2]] <- flip(b[[2]], 'y') + runif(ncell(b))
b[[1]] <- b[[1]] + runif(ncell(b))
b[[2]][b[[2]]>230] <- NA
b[[1]][is.na(b[[2]])] <- NA

x <- corLocal(b[[1]], b[[2]] )
plot(x)

Error in setValues(out, v) : 
  length(values) is not equal to ncell(x), or to 1

The issue is solved by this simple patch of deleting "nrow =
