### PR TITLE
Fixed scalebar so that 'below' argument works for lines

### DIFF
--- a/R/scalebar.R
+++ b/R/scalebar.R
@@ -136,9 +136,13 @@ scalebar <- function(d, xy=NULL, type='line', divs=2, below='', lonlat=NULL, lab
 			text(end, xy[2],labels=label[3], adj=adj,...)
 		}
 			
-		if (below != "") {
-			adj[2] <- -adj[2]
-			text(xy[1]+(0.5*dd), xy[2], labels=below, adj=adj,...)
-		}
+	}
+	if (below!= "") {
+		adj[2] <- -adj[2]
+		if (type=="line"){
+		   #Add a bit of space to account for the line
+      		   adj[2] <- adj[2] + .8
+    		}
+		text(xy[1]+(0.5*dd), xy[2], labels=below, adj=adj,...)
 	}
 }


### PR DESCRIPTION
From reading the documentation, it sounds like the `below` argument to `scalebar` is supposed to work for both types of scalebar (line and bar). However, `below` currently only has an effect if `type==bar`. This change swaps the location of the code that processes `below` around slightly so that the text shows up on both types of scalebar, and adjusts the y coordinate in `adj` appropriately to avoid placing the `below` text on top of the line.
